### PR TITLE
Add Albert configuration and remove Kupfer keybinding

### DIFF
--- a/dotfiles/.config/albert/albert.conf
+++ b/dotfiles/.config/albert/albert.conf
@@ -1,0 +1,46 @@
+[General]
+frontendId=org.albert.frontend.widgetboxmodel
+hotkey=Ctrl+Space
+showTray=false
+telemetry=false
+terminal=xfce4-terminal -x
+
+[org.albert.extension.applications]
+enabled=true
+
+[org.albert.extension.calculator]
+enabled=true
+
+[org.albert.extension.files]
+enabled=true
+filters=inode/directory, application/*, audio/*, video/*, image/*
+
+[org.albert.extension.python]
+enabled=false
+
+[org.albert.extension.terminal]
+enabled=false
+
+[org.albert.extension.websearch]
+enabled=true
+
+[org.albert.frontend.qmlboxmodel]
+alwaysOnTop=true
+clearOnHide=false
+hideOnClose=false
+hideOnFocusLoss=true
+showCentered=true
+stylePath=/usr/share/albert/org.albert.frontend.qmlboxmodel/styles/BoxModel/MainComponent.qml
+windowPosition=@Point(352 141)
+
+[org.albert.frontend.widgetboxmodel]
+alwaysOnTop=true
+clearOnHide=true
+displayIcons=true
+displayScrollbar=false
+displayShadow=true
+hideOnClose=false
+hideOnFocusLoss=true
+itemCount=6
+showCentered=true
+theme=Adapta

--- a/dotfiles/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
+++ b/dotfiles/.config/xfce4/xfconf/xfce-perchannel-xml/xfce4-keyboard-shortcuts.xml
@@ -23,9 +23,6 @@
       <property name="&lt;Control&gt;Escape" type="empty"/>
     </property>
     <property name="custom" type="empty">
-      <property name="&lt;Alt&gt;F3" type="string" value="kupfer">
-        <property name="startup-notify" type="bool" value="true"/>
-      </property>
       <property name="&lt;Primary&gt;&lt;Alt&gt;Delete" type="string" value="xflock4"/>
       <property name="XF86Mail" type="string" value="exo-open --launch MailReader"/>
       <property name="XF86WWW" type="string" value="exo-open --launch WebBrowser"/>
@@ -48,6 +45,7 @@
       <property name="&lt;Super&gt;k" type="string" value="keepassxc"/>
       <property name="&lt;Super&gt;Return" type="string" value="tilix"/>
       <property name="&lt;Super&gt;s" type="string" value="skippy-xd"/>
+      <property name="&lt;Alt&gt;F3" type="string" value="xfce4-appfinder --collapsed"/>
     </property>
   </property>
   <property name="xfwm4" type="empty">


### PR DESCRIPTION
Add Albert configuration file. Remove Kupfer keybinding and restore it to the original `xfce4-appfinder --collapsed`.