### PR TITLE
Update .condarc with more configurations

### DIFF
--- a/dotfiles/.condarc
+++ b/dotfiles/.condarc
@@ -1,4 +1,22 @@
+# Conda configuration based on
+# https://gist.github.com/ocefpaf/863fc5df6ed8444378fbb1211ad8feb1
+# See https://www.anaconda.com/understanding-and-improving-condas-performance/
+# for more info.
+
+# help debug channel issues
+show_channel_urls: true
+
+# pip will always be installed with python
+add_pip_as_python_dependency: true
+
+# strict priority and conda-forge at the top will ensure
+# that all of your packages will be from conda-forge unless they only exist on
+# defaults
+channel_priority: strict
 channels:
   - conda-forge
   - defaults
-ssl_verify: true
+
+# when using "conda create" for envs these packages will always be installed
+create_default_packages:
+  - ipython


### PR DESCRIPTION
Make conda-forge the first channel from which packages should be downloaded
from. Install `ipython` on every new environment. Add `pip` as a Python
dependency.
