### PR TITLE
Add packages_yay.yml file with packages from AUR

### DIFF
--- a/yay_packages.yml
+++ b/yay_packages.yml
@@ -43,3 +43,5 @@ hub-bin:
 zotero:
   - zotero
 
+photofilmstrip:
+  - photofilmstrip

--- a/yay_packages.yml
+++ b/yay_packages.yml
@@ -1,0 +1,45 @@
+jabref:
+  - jabref
+
+diceware:
+  - diceware
+
+simplenote-electron-bin:
+- simplenote-electron-bin
+
+google-earth-pro:
+- google-earth-pro
+
+fontawesome.sty:
+- fontawesome.sty
+
+pdftk:
+- pdftk
+
+ttf-google-fonts-git:
+- ttf-google-fonts-git
+
+audio-recorder:
+- audio-recorder
+
+gplates:
+- gplates
+
+spotify:
+- spotify
+
+trello:
+- trello
+
+slack-desktop:
+- slack-desktop
+
+zoom:
+- zoom
+
+hub-bin:
+- hub-bin
+
+zotero:
+  - zotero
+


### PR DESCRIPTION
Add a separate YAML file containing a list of all packages that I usually install from AUR.
The file is intended to work with future versions of Settle, after `yay` is added as a package manager.