### PR TITLE
Set alacritty as default terminal for i3

### DIFF
--- a/dotfiles/.alacritty.yml
+++ b/dotfiles/.alacritty.yml
@@ -1,0 +1,48 @@
+window:
+  padding:
+    x: 15
+    y: 15
+
+font:
+  size: 10
+  normal:
+    family: Fira Code
+    style: Regular
+
+  bold:
+    family: Fira Code
+    style: Bold
+
+  italic:
+    family: Fira Code
+    style: Italic
+
+  bold_italic:
+    family: Fira Code
+    style: Bold Italic
+
+# Colorscheme: One Dark
+colors:
+  primary:
+    background: "0x282C34"
+    foreground: "0xabb2bf"
+
+  normal:
+    black: "0x1e2127"
+    red: "0xe06c75"
+    green: "0x98c379"
+    yellow: "0xe5c07b"
+    blue: "0x61afef"
+    magenta: "0xc678dd"
+    cyan: "0x56b6c2"
+    white: "0xabb2bf"
+
+  bright:
+    black: "0x5c6370"
+    red: "0xe06c75"
+    green: "0x98c379"
+    yellow: "0xe5c07b"
+    blue: "0x61afef"
+    magenta: "0xc678dd"
+    cyan: "0x56b6c2"
+    white: "0xffffff"

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -58,7 +58,7 @@ gaps inner 6
 gaps outer 0
 
 # Smart gaps (gaps used if only more than one container on the workspace)
-smart_gaps on
+# smart_gaps on
 
 # Smart borders (draw borders around container only if it is not the only container on this workspace)
 # on|no_gaps (on=always activate and no_gaps=only activate if the gap size to the edge of the screen is 0)
@@ -160,16 +160,17 @@ bindsym $mod+Shift+9 move container to workspace $ws9; workspace $ws9
 bindsym $mod+p move workspace to output right
 
 # Start Applications
-bindsym $mod+Return exec xfce4-terminal
-bindsym $mod+Ctrl+b exec terminal -e 'bmenu'
+bindsym $mod+Return exec i3-sensible-terminal
+bindsym $mod+Ctrl+b exec i3-sensible-terminal -e 'bmenu'
 bindsym $mod+F2 exec firefox
 bindsym $mod+F3 exec thunar
 bindsym $mod1+F2 exec xfce4-appfinder
 bindsym $mod+Shift+F3 exec pcmanfm_pkexec
-bindsym $mod+F5 exec terminal -e 'mocp'
+bindsym $mod+F5 exec i3-sensible-terminal -e 'mocp'
 bindsym $mod+t exec --no-startup-id pkill picom
 bindsym $mod+Ctrl+t exec --no-startup-id picom -b
 bindsym $mod+Shift+d --release exec "killall dunst; exec notify-send 'restart dunst'"
+bindsym $mod+n exec --no-startup-ud notify-send "DUNST_COMMAND_TOGGLE"
 bindsym Print exec --no-startup-id i3-scrot
 bindsym $mod+Print --release exec --no-startup-id i3-scrot -w
 bindsym $mod+Shift+Print --release exec --no-startup-id i3-scrot -s
@@ -304,6 +305,8 @@ assign [class="TelegramDesktop"] $ws4
 assign [class="Gimp"] $ws5
 assign [class="Inkscape"] $ws5
 assign [class="Darktable"] $ws5
+assign [class="smplayer"] $ws6
+assign [class="mpv"] $ws6
 assign [class="Lollypop"] $ws6
 assign [class="Steam"] $ws6
 assign [class="zoom"] $ws6
@@ -372,7 +375,13 @@ exec --no-startup-id nextcloud
 exec --no-startup-id orage
 exec_always --no-startup-id sleep 1; $HOME/.config/polybar/launch.sh
 exec --no-startup-id nitrogen --restore
-# exec --no-startup-id nitrogen --restore; sleep 1; picom -b
+exec --no-startup-id picom -b
+
+exec --no-startup-id slack
+exec --no-startup-id telegram-desktop
+exec --no-startup-id firefox
+
+
 
 ################################################################################################
 ## sound-section - DO NOT EDIT if you wish to automatically upgrade Alsa -> Pulseaudio later! ##

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -376,7 +376,6 @@ exec_always --no-startup-id sleep 1; $HOME/.config/polybar/launch.sh
 exec --no-startup-id nitrogen --restore
 # exec --no-startup-id nitrogen --restore; sleep 1; picom -b
 
-
 ################################################################################################
 ## sound-section - DO NOT EDIT if you wish to automatically upgrade Alsa -> Pulseaudio later! ##
 ################################################################################################

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -170,7 +170,6 @@ bindsym $mod+F5 exec i3-sensible-terminal -e 'mocp'
 bindsym $mod+t exec --no-startup-id pkill picom
 bindsym $mod+Ctrl+t exec --no-startup-id picom -b
 bindsym $mod+Shift+d --release exec "killall dunst; exec notify-send 'restart dunst'"
-bindsym $mod+n exec --no-startup-ud notify-send "DUNST_COMMAND_TOGGLE"
 bindsym Print exec --no-startup-id i3-scrot
 bindsym $mod+Print --release exec --no-startup-id i3-scrot -w
 bindsym $mod+Shift+Print --release exec --no-startup-id i3-scrot -s
@@ -375,12 +374,7 @@ exec --no-startup-id nextcloud
 exec --no-startup-id orage
 exec_always --no-startup-id sleep 1; $HOME/.config/polybar/launch.sh
 exec --no-startup-id nitrogen --restore
-exec --no-startup-id picom -b
-
-exec --no-startup-id slack
-exec --no-startup-id telegram-desktop
-exec --no-startup-id firefox
-
+# exec --no-startup-id nitrogen --restore; sleep 1; picom -b
 
 
 ################################################################################################

--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -3,3 +3,4 @@ export EDITOR=/usr/bin/nvim
 export GTK2_RC_FILES="$HOME/.gtkrc-2.0"
 # fix "xdg-open fork-bomb" export your preferred browser from here
 export BROWSER=/usr/bin/firefox
+export TERMINAL=/usr/bin/alacritty

--- a/packages.yml
+++ b/packages.yml
@@ -2,7 +2,7 @@ i3-gaps extra:
   - thunar
   - thunar-archive-plugin
   - firefox
-  - xfce4-terminal
+  - alacritty
   - neovim
   - python-pynvim
   - pavucontrol


### PR DESCRIPTION
Replace `xfce4-terminal` for  `alacritty` in `packages.yml`.
Add `.alacritty.yml` configuration file with Fira Code font, One Dark
colorscheme and custom padding. Set `alacritty` as default terminal by setting
the `$TERMINAL` env variable on `.profile`.