### PR TITLE
Set inactive window dim on picom

### DIFF
--- a/dotfiles/.config/picom.conf
+++ b/dotfiles/.config/picom.conf
@@ -393,10 +393,10 @@ log-level = "warn";
 #
 wintypes:
 {
-  tooltip = { fade = true; shadow = false; opacity = 0.75; focus = true; full-shadow = false; };
+  # tooltip = { fade = true; shadow = false; opacity = 0.75; focus = true; full-shadow = false; };
   dock = { shadow = true; shadow-radius = 3;}
   dnd = { shadow = false; }
-  popup_menu = { opacity = 0.9; }
-  dropdown_menu = { opacity = 0.9; }
-  notification = { opacity = 0.5; }
+  # popup_menu = { opacity = 0.9; }
+  # dropdown_menu = { opacity = 0.9; }
+  # notification = { opacity = 0.5; }
 };

--- a/dotfiles/.config/picom.conf
+++ b/dotfiles/.config/picom.conf
@@ -118,7 +118,7 @@ fade-delta = 3
 # active-opacity = 1.0
 
 # Dim inactive windows. (0.0 - 1.0, defaults to 0.0)
-inactive-dim = 0.15
+inactive-dim = 0.2
 
 # Specify a list of conditions of windows that should always be considered focused.
 # focus-exclude = []

--- a/dotfiles/.config/picom.conf
+++ b/dotfiles/.config/picom.conf
@@ -118,11 +118,12 @@ fade-delta = 3
 # active-opacity = 1.0
 
 # Dim inactive windows. (0.0 - 1.0, defaults to 0.0)
-# inactive-dim = 0.0
+inactive-dim = 0.15
 
 # Specify a list of conditions of windows that should always be considered focused.
 # focus-exclude = []
 # focus-exclude = [ "class_g = 'Cairo-clock'" ];
+focus-exclude = [ "class_g = 'Steam'" ];
 
 # Use fixed inactive dim value, instead of adjusting according to window opacity.
 # inactive-dim-fixed = 1.0
@@ -260,8 +261,8 @@ detect-transient = true;
 # group focused at the same time. 'WM_TRANSIENT_FOR' has higher priority if
 # detect-transient is enabled, too.
 #
-# detect-client-leader = false
-detect-client-leader = true;
+detect-client-leader = false
+# detect-client-leader = true;
 
 # Resize damaged region by a specific number of pixels.
 # A positive value enlarges it while a negative one shrinks it.

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -39,7 +39,7 @@ set $orange         #E5C07B
 set $red            #E06C75
 
 # class                 border      background      text            indic.      child_border
-client.focused          $background $background     $green          $orange     $green
+client.focused          $background $background     $foreground     $orange     $background
 client.focused_inactive $background $background     $foreground-alt $background $background
 client.unfocused        $background $background-alt $foreground-alt $background $background
 client.urgent           $background $background     $orange         $background $background
@@ -350,6 +350,10 @@ for_window [class="Arandr"] floating enable border normal; resize shrink width 4
 for_window [class="Jitsi Meet"] floating enable border normal
 for_window [class="Gcolor3"] floating enable border none
 for_window [class="Pavucontrol"] floating enable
+
+
+
+for_window [class="Xfce4-terminal"] border none
 
 # Switch focus when a new window of the following applications is opened
 for_window [class="firefox"] focus

--- a/dotfiles/.i3/config
+++ b/dotfiles/.i3/config
@@ -58,7 +58,7 @@ gaps inner 6
 gaps outer 0
 
 # Smart gaps (gaps used if only more than one container on the workspace)
-# smart_gaps on
+smart_gaps on
 
 # Smart borders (draw borders around container only if it is not the only container on this workspace)
 # on|no_gaps (on=always activate and no_gaps=only activate if the gap size to the edge of the screen is 0)


### PR DESCRIPTION
Enable inactive-dim on picom. Only set active the current focused window and not its entire
family. Don't make i3 window border green when active.
Remove all sort of borders from xfce4-terminal.

