### PR TITLE
Configure coc-python to use the current conda env

### DIFF
--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -287,3 +287,11 @@ nmap <silent> gd <Plug>(coc-definition)
 nmap <silent> gy <Plug>(coc-type-definition)
 nmap <silent> gi <Plug>(coc-implementation)
 nmap <silent> gr <Plug>(coc-references)
+
+" Use the current conda environment
+if $CONDA_PREFIX == ""
+  let s:current_python_path=$CONDA_PYTHON_EXE
+else
+  let s:current_python_path=$CONDA_PREFIX.'/bin/python'
+endif
+call coc#config('python', {'pythonPath': s:current_python_path})


### PR DESCRIPTION
Reference: https://github.com/neoclide/coc-python/issues/55#issuecomment-617499047
