### PR TITLE
Fix alternative black color in OneHalfDark

### DIFF
--- a/dotfiles/.config/terminator/config
+++ b/dotfiles/.config/terminator/config
@@ -25,7 +25,7 @@
     show_titlebar = False
     scrollbar_position = hidden
     scrollback_lines = 10000
-    palette = "#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
+    palette = "#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#abb2bf:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
     use_system_font = False
 [layouts]
   [[default]]

--- a/dotfiles/.config/xfce4/terminal/colorschemes/OneHalfDark.theme
+++ b/dotfiles/.config/xfce4/terminal/colorschemes/OneHalfDark.theme
@@ -55,4 +55,4 @@ ColorBold=#dcdfe4
 ColorBoldUseDefault=FALSE
 ColorCursor=#282C34
 #TabActivityColor=
-ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4
+ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#abb2bf;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4


### PR DESCRIPTION
Replace the alternative black color in OneHalfDark for terminator and
xfce4-terminal for a grey color.
This makes some characters visible in htop.